### PR TITLE
seo: add seo_title and description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,6 @@
 # you will see them accessed via {{ site.title }}, {{ site.github_repo }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: BitBox
 description: Shift Crypto product user guides
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://guides.shiftcrypto.ch" # the base hostname & protocol for your site, e.g. http://example.com

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,14 +1,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-
-  {% if site.plugins.jekyll-seo == nil %}
-    <title>{{ page.title }} - {{ site.title }}</title>
-
-    {% if page.description %}
-      <meta name="Description" content="{{ page.description }}">
-    {% endif %}
-  {% endif %}
+  <title>{{ page.seo_title }}</title>
 
   <link rel="icon" type="image/png" href="{{ 'assets/favicons/favicon-16.png' | relative_url }}" sizes="16x16" />
   <link rel="icon" type="image/png" href="{{ 'assets/favicons/favicon-32.png' | relative_url }}" sizes="32x32" />
@@ -46,7 +39,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% seo %}
+  {% seo title=false %}
 
   {% include head_custom.html %}
 

--- a/bitbox01/advanced/index.md
+++ b/bitbox01/advanced/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Advanced features
+seo_title: BitBox01 - Advanced features
 nav_order: 3
 has_children: true
 parent: BitBox01
+description: Here you will find guides for advanced BitBox01 features.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox01/advanced/pairing.md
+++ b/bitbox01/advanced/pairing.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Mobile app pairing
+seo_title: BitBox01 - Mobile app pairing
 nav_order: 1
 parent: Advanced features
 grand_parent: BitBox01
+description: Learn more about the BitBox01 mobile pairing.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox01/advanced/reset.md
+++ b/bitbox01/advanced/reset.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Reset device
+seo_title: BitBox01 - Reset device
 nav_order: 2
 parent: Advanced features
 grand_parent: BitBox01
-
+description: Find out how to reset your BitBox02 hardware wallet.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox01/basics/device-settings.md
+++ b/bitbox01/basics/device-settings.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Device settings
+seo_title: BitBox01 - Device settings
 nav_order: 4
 has_children: false
 parent: Basic features
 grand_parent: BitBox01
+description: Learn more about the BitBox01 device settings.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/basics/history.md
+++ b/bitbox01/basics/history.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Transaction history
+seo_title: BitBox01 - Transaction history
 nav_order: 3
 has_children: false
 parent: Basic features
 grand_parent: BitBox01
+description: Learn about the transaction history page in the BitBoxApp.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/basics/index.md
+++ b/bitbox01/basics/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Basic features
+seo_title: BitBox01 - Basic features
 nav_order: 2
 has_children: true
 parent: BitBox01
+description: Here you will find the most common BitBox01 guides for its basic features.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox01/basics/managing-backups.md
+++ b/bitbox01/basics/managing-backups.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Managing backups
+seo_title: BitBox01 - Managing backups
 nav_order: 5
 has_children: false
 parent: Basic features
 grand_parent: BitBox01
+description: Find out how to manage wallet backups using your BitBox01.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/basics/receive.md
+++ b/bitbox01/basics/receive.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Receiving payments
+seo_title: BitBox01 - Receiving payments
 nav_order: 1
 has_children: false
 parent: Basic features
 grand_parent: BitBox01
+description: Learn how to receive coins on your BitBox01.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/basics/restore-from-backup.md
+++ b/bitbox01/basics/restore-from-backup.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Restore from backup
+seo_title: BitBox01 - Restore from backup
 nav_order: 6
 parent: Basic features
 grand_parent: BitBox01
+description: Find out how to restore your BitBox01 wallet from your microSD card backup.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/basics/send.md
+++ b/bitbox01/basics/send.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Sending payments
+seo_title: BitBox01 - Sending payments
 nav_order: 2
 has_children: false
 parent: Basic features
 grand_parent: BitBox01
+description: Learn how to make transactions from your BitBox01.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox01/eol-faqs.md
+++ b/bitbox01/eol-faqs.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: End-of-sale/life FAQs
+seo_title: BitBox01 - End-of-sale/life FAQs
 nav_order: 6
 has_children: false
 parent: BitBox01
+description: As of 12 November 2019, the BitBox01 is no longer available for purchase. If you are a BitBox01 owner, please read through the FAQs below.
 ---
 
 # BitBox01 end-of-sale/life FAQs

--- a/bitbox01/index.md
+++ b/bitbox01/index.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: BitBox01
+seo_title: BitBox01 - Product guides
 nav_order: 2
 has_children: true
+description: All products guides for the BitBox01 ("Digital BitBox") hardware wallet can be found here.
 ---
 
 # {{page.title}}

--- a/bitbox01/other/backup-center.md
+++ b/bitbox01/other/backup-center.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Backup center (BitBox01 aka. Digital BitBox)
+seo_title: BitBox01 - Backup center
 nav_order: 3
 has_children: false
 parent: Other guides
 grand_parent: BitBox01
+description: Find out how to use the BitBox01 backup center. This tool should only be used if absolutely necessary.
 ---
 # {{page.title}}
 {: .no_toc }

--- a/bitbox01/other/blink.md
+++ b/bitbox01/other/blink.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Blink patterns
+seo_title: BitBox01 - Blink patterns
 nav_order: 2
 has_children: false
 parent: Other guides
 grand_parent: BitBox01
+description: Learn more about the different blink patterns of the BitBox01 LED.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox01/other/ethereum.md
+++ b/bitbox01/other/ethereum.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Ethereum integration
+seo_title: BitBox01 - Ethereum integration
 nav_order: 1
 has_children: false
 parent: Other guides
 grand_parent: BitBox01
+description: This guide explains how to use your BitBox01 with the popular MyEtherWallet tool.
 ---
 # {{page.title}}
 {: .no_toc }

--- a/bitbox01/other/index.md
+++ b/bitbox01/other/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Other guides
+seo_title: BitBox01 - Other guides
 nav_order: 4
 has_children: true
 parent: BitBox01
+description: Here you can find guides for less common BitBox01 topics.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox01/other/sweep-to-bitbox02.md
+++ b/bitbox01/other/sweep-to-bitbox02.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Sweep funds from BitBox01 to BitBox02
+seo_title: How to transfer my coins from a BitBox01 to BitBox02?
 nav_order: 4
 has_children: false
 parent: Other guides
 grand_parent: BitBox01
+description: This guide explains how to transfer the coins stored on your BitBox01 to a BitBox02 hardware wallet.
 ---
 # {{page.title}}
 {: .no_toc }

--- a/bitbox01/other/wallet-sweep.md
+++ b/bitbox01/other/wallet-sweep.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Sweep guide
+seo_title: BitBox01 - How to sweep my wallet?
 nav_order: 5
 has_children: false
 parent: Other guides
 grand_parent: BitBox01
+description: This guide explains how to sweep the coins in your BitBox01 wallet to another wallet. 
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox01/setup.md
+++ b/bitbox01/setup.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Setup
+seo_title: BitBox01 - Setup
 nav_order: 1
 has_children: false
 parent: BitBox01
+description: This guide explains how to setup your BitBox01 hardware wallet.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox02/Troubleshooting/index.md
+++ b/bitbox02/Troubleshooting/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Troubleshooting
+seo_title: BitBox02 - Troubleshooting
 nav_order: 5
 has_children: true
 parent: BitBox02

--- a/bitbox02/Troubleshooting/mew_troubleshooting.md
+++ b/bitbox02/Troubleshooting/mew_troubleshooting.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: MyEtherWallet
+seo_title: BitBox02 - How to use a BitBox02 with MyEtherWallet?
 nav_order: 1
 has_children: false
 parent: Troubleshooting
 grand_parent: BitBox02
+description: Find out how to use your BitBox02 with the popular MyEtherWallet tool.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/Troubleshooting/touch_sensors.md
+++ b/bitbox02/Troubleshooting/touch_sensors.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Touch sensors
+seo_title: BitBox02 - Touch sliders
 nav_order: 3
 has_children: false
 parent: Troubleshooting
 grand_parent: BitBox02
+description: Learn more about how the BitBox02 touch sensors work.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/Troubleshooting/usb_connection.md
+++ b/bitbox02/Troubleshooting/usb_connection.md
@@ -1,11 +1,13 @@
 ---
 layout: default
 title: USB connection
+seo_title: BitBox02 - USB connection
 nav_order: 2
 has_children: false
 parent: Troubleshooting
 grand_parent: BitBox02
 redirect_from: /bitbox02/Troubleshooting/mew_troubleshooting2/
+description: Read this guide if you are having USB issues with your BitBox02.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/advanced/backup-recovery.md
+++ b/bitbox02/advanced/backup-recovery.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Backup recovery tool
+seo_title: BitBox02 - Backup recovery tool
 nav_order: 6
 has_children: false
 parent: Advanced features
 grand_parent: BitBox02
+description: Find out how to use the BitBox02 backup center. This tool should only be used if absolutely necessary.
 ---
 # {{page.title}}
 {: .no_toc }

--- a/bitbox02/advanced/index.md
+++ b/bitbox02/advanced/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Advanced features
+seo_title: BitBox02 - Advanced features
 nav_order: 4
 has_children: true
 parent: BitBox02
+description: Learn about the advanced features of your BitBox02
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox02/advanced/passphrase.md
+++ b/bitbox02/advanced/passphrase.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Optional passphrase
+seo_title: BitBox02 - How to use an optional passphrase?
 nav_order: 3
 parent: Advanced features
 grand_parent: BitBox02
+description: Learn about how to use the optional passphrase feature of your BitBox02
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/advanced/reproducible-builds.md
+++ b/bitbox02/advanced/reproducible-builds.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Reproducible builds
+seo_title: BitBox02 - What are reproducible builds?
 parent: Advanced features
 grand_parent: BitBox02
 nav_order: 4
+description: Learn more about reproducible builds and why they are important.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox02/advanced/reset.md
+++ b/bitbox02/advanced/reset.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Reset device
+seo_title: BitBox02 - How to reset a BitBox02?
 nav_order: 5
 parent: Advanced features
 grand_parent: BitBox02
-
+description: Find out how to reset your BitBox02 hardware wallet.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox02/advanced/view-seed.md
+++ b/bitbox02/advanced/view-seed.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Display recovery words
+seo_title: BitBox02 - How to display my wallet recovery words?
 nav_order: 2
 parent: Advanced features
 grand_parent: BitBox02
-
+description: Find out how to display the wallet recovery words on the display of your BitBox02.
 ---
 # {{page.grand_parent}}: {{page.title}}
 {: .no_toc }

--- a/bitbox02/basics/device-settings.md
+++ b/bitbox02/basics/device-settings.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Device settings
+seo_title: BitBox02 - Device settings
 nav_order: 4
 has_children: false
 parent: Basic features
 grand_parent: BitBox02
+description: Learn more about the BitBox02 device settings.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/basics/history.md
+++ b/bitbox02/basics/history.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Transaction history
+seo_title: BitBox02 - Transaction history
 nav_order: 3
 has_children: false
 parent: Basic features
 grand_parent: BitBox02
+description: Learn about the transaction history page in the BitBoxApp.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/basics/index.md
+++ b/bitbox02/basics/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Basic features
+seo_title: BitBox02 - Basic features
 nav_order: 3
 has_children: true
 parent: BitBox02
+description: Learn about the basic features of your BitBox02
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox02/basics/managing-backups.md
+++ b/bitbox02/basics/managing-backups.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Managing backups
+seo_title: BitBox02 - How to manage wallet backups?
 nav_order: 5
 has_children: false
 parent: Basic features
 grand_parent: BitBox02
+description: Learn more about how to manage your wallet backups with your BitBox02.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/basics/receive.md
+++ b/bitbox02/basics/receive.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Receiving payments
+seo_title: BitBox02 - How to receive a payment?
 nav_order: 1
 has_children: false
 parent: Basic features
 grand_parent: BitBox02
+description: Find out how to receive coins on your BitBox02 hardware wallet.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/basics/restore-from-backup.md
+++ b/bitbox02/basics/restore-from-backup.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Restore from backup
+seo_title: BitBox02 - How to restore from a microSD card backup?
 nav_order: 6
 parent: Basic features
 grand_parent: BitBox02
+description: Find out how to restore your wallet from your microSD card.
 ---
 
 # {{page.grand_parent}}: {{page.title}}
@@ -16,7 +18,7 @@ grand_parent: BitBox02
 {:toc}
 ---
 
-In order to reset from a backup, your BitBox02 needs to be reset.
+In order to restore from a backup, your BitBox02 needs to be reset.
 
 ## Plug in the microSD card containing your backup and plug in the BitBox02
 In order to be able to restore from a backup, the microSD card containing the backup needs to be inserted. Once done, plug in your BitBox02 with the BitBoxApp open.

--- a/bitbox02/basics/send.md
+++ b/bitbox02/basics/send.md
@@ -1,10 +1,12 @@
 ---
 layout: default
 title: Sending payments
+seo_title: BitBox02 - How to send a payment?
 nav_order: 2
 has_children: false
 parent: Basic features
 grand_parent: BitBox02
+description: Find out how to send coins from your BitBox02 hardware wallet.
 ---
 
 # {{page.grand_parent}}: {{page.title}}

--- a/bitbox02/index.md
+++ b/bitbox02/index.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: BitBox02
+seo_title: BitBox02 - Explore the product guides
 nav_order: 3
 has_children: true
+description: All products guides for the BitBox02 hardware wallet can be found here.
 ---
 # {{page.title}}
 {: .no_toc }

--- a/bitbox02/setup.md
+++ b/bitbox02/setup.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Setup
+seo_title: How to setup a BitBox02 hardware wallet?
 nav_order: 2
 has_children: false
 parent: BitBox02
+description: This guide explains how to setup your BitBox02 hardware wallet.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitbox02/unboxing.md
+++ b/bitbox02/unboxing.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Unboxing
+seo_title: BitBox02 - Unboxing
 nav_order: 1
 has_children: false
 parent: BitBox02
+description: In this guide we will go through the BitBox02 unboxing.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/addresses.md
+++ b/bitboxapp/addresses.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Address types
+seo_title: BitBoxApp - What are unified accounts and what are the different address types?
 nav_order: 2
 has_children: false
 parent: BitBoxApp
-
+description: Learn more about the different address formats available in the BitBoxApp.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/coin-control.md
+++ b/bitboxapp/coin-control.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Coin control
+seo_title: BitBoxApp - What is coin control and how can I use it?
 nav_order: 3
 has_children: false
 parent: BitBoxApp
-
+description: Find out what coin control is and how to use it when making transactions.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/full-node.md
+++ b/bitboxapp/full-node.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Full node support
+seo_title: BitBoxApp - Why should I run my own full node and how can I connect my BitBoxApp to it?
 nav_order: 4
 has_children: false
 parent: BitBoxApp
+description: Learn more about why running a full node is important and how you can connect your full node to your BitBoxApp.
 ---
 
 # {{page.parent}}: {{page.title}}
@@ -57,4 +59,4 @@ If you have Tor installed on your computer, you can access your own node remotel
 - Enable the proxy and confirm the proxy address.
   - If you are running the TOR deamon it probably is: `127.0.0.1:9050`
   - If you are running the TOR browser it probably is: `127.0.0.1:9150`
-- Then restart the BitBoxApp in order for the new settings to take effect. 
+- Then restart the BitBoxApp in order for the new settings to take effect.

--- a/bitboxapp/gap-limit.md
+++ b/bitboxapp/gap-limit.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Gap limits
+seo_title: BitBoxApp - How to change the gap limits?
 nav_order: 7
 has_children: false
 parent: BitBoxApp
-
+description: Find out how to change the BitBoxApp gap limits.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/index.md
+++ b/bitboxapp/index.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: BitBoxApp
+seo_title: BitBoxApp - How to install the BitBoxApp?
 nav_order: 5
 nav_exclude: false
 has_children: true
+description: Find out how to install the BitBox for your operating system.
 ---
 
 # {{page.title}}

--- a/bitboxapp/privacy.md
+++ b/bitboxapp/privacy.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Privacy
+seo_title: BitBoxApp - Which details are shared with Shift company servers?
 nav_order: 5
 has_children: false
 parent: BitBoxApp
-
+description: Learn more about what data is shared with the Shift company servers when using the BitBoxApp without your own full node.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/settings.md
+++ b/bitboxapp/settings.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Settings
+seo_title: BitBoxApp - How to customize the BitBoxApp?
 nav_order: 6
 has_children: false
 parent: BitBoxApp
-
+description: Find out how to customize the BitBoxApp to your needs.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/transactions.md
+++ b/bitboxapp/transactions.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Transactions
+seo_title: BitBoxApp - How to see transaction details and make notes?
 nav_order: 1
 has_children: false
 parent: BitBoxApp
+description: Learn more about transaction types, notes and details in the BitBoxApp.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/verify-release.md
+++ b/bitboxapp/verify-release.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Verify release
+seo_title: BitBoxApp - How to verify a new BitBoxApp release?
 nav_order: 8
 has_children: false
 parent: BitBoxApp
+description: Find out how to verify a BitBoxApp release.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/bitboxapp/xpub.md
+++ b/bitboxapp/xpub.md
@@ -1,10 +1,11 @@
 ---
 layout: default
 title: Extended public key
+seo_title: BitBoxApp - How to access my wallet extended public key?
 nav_order: 3
 has_children: false
 parent: BitBoxApp
-
+description: Find out how to access the extended public key of your BitBox02 wallet.
 ---
 
 # {{page.parent}}: {{page.title}}

--- a/index.md
+++ b/index.md
@@ -1,8 +1,10 @@
 ---
 layout: default
-title: Home
+title: BitBox Guides
+seo_title: BitBox Guides
 nav_order: 1
-description: "Shift Crypto product user guides"
+description: "The official product guides for BitBox products."
+nav_exclude: true
 ---
 Please select the product you would like to see the guides for or use the searchbar to search for a keyword:
 {: .fs-6 .fw-300 }

--- a/steelwallet/index.md
+++ b/steelwallet/index.md
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: Steelwallet
+seo_title: Steelwallet - How to setup a Steelwallet?
 nav_order: 5
 has_children: false
+description: Find out what a Steelwallet is and how to set it up.
 ---
 
 # {{page.title}}


### PR DESCRIPTION
- Add seo_title for each page
- Add description for each page

This change allows us to set a separate value for the `<title>` tag via the `seo_title` page variable. 
It also introduces values for the meta description tag for each page. 

Open issue: I can't disable the "og:title" tag in the seo plugin which uses `page.title` whereas`<title>` gets its value from `page.seo_title`. Meaning they have different values. 
Is that an issue for SEO ranking? I don't mind if cards on twitter have a different title compared to the search results on google etc. @thisconnect 