### PR TITLE
fix partly rendered search preview

### DIFF
--- a/assets/js/zzzz-search-data
+++ b/assets/js/zzzz-search-data
@@ -1,4 +1,5 @@
 ---
+permalink: /assets/js/search-data.json
 ---
 {
   {% for page in site.html_pages %}{% if page.search_exclude != true %}"{{ forloop.index0 }}": {


### PR DESCRIPTION
The preview in search results dropdown showed sometimes jekyll
includes when it should display text snippets of the results.

The problem is when search-data.json is rendered every file after
S has not been rendered yet as jekyll processes all files in
alphabetical order. In that case the search might display jekyll
includes or raw markdown.

Renaming search-data.json to zzzz-search-data with a permalink
fixes this, see upstream fix. Also removed .json as the file
is a template that will render to JSON.

https://github.com/pmarsceill/just-the-docs/issues/191#issuecomment-557836956